### PR TITLE
make AT_NORM_CHAR/AT_GREY_SPACE trn4t77 compatible

### DIFF
--- a/tests/test_rt-util.c
+++ b/tests/test_rt-util.c
@@ -44,10 +44,24 @@ static char *test_compress_name__PCS () {
     return 0;
 }
 
+static char *test_subject_has_Re__1 () {
+    char *before = "Re: followup";
+    char *after;
+    char *expected = "followup";
+    subject_has_Re(before, &after);
+    printf("Test %d:\n", tests_run);
+    printf("Before   : \"%s\"\n", before);
+    printf("After    : \"%s\"\n", after);
+    printf("Expected : \"%s\"\n", expected);
+    mu_assert("error, \"followup\" != \"followup\"", strcmp(after, expected) == 0);
+    return 0;
+}
+
 
 /* main loop */
 
 static char *all_tests() {
+    mu_run_test(test_subject_has_Re__1);
     mu_run_test(test_compress_name__SAIC);
     mu_run_test(test_compress_name__PCS);
     return 0;

--- a/utf.c
+++ b/utf.c
@@ -391,6 +391,7 @@ at_norm_char(s)
 const char *s;
 {
     int it = s != NULL;
+    if (it) { it = *s != 0; }
     if (it) {
 	if (gs.in == CHARSET_UTF8) {
 	    CODE_POINT c = code_point_at(s);

--- a/util.h
+++ b/util.h
@@ -15,7 +15,7 @@ EXT bool export_nntp_fds INIT(FALSE);
 EXT int len_last_line_got INIT(0);
 EXT MEM_SIZE buflen_last_line_got INIT(0);
 
-#define AT_GREY_SPACE(s) !at_norm_char(s)
+#define AT_GREY_SPACE(s) ((s) && ((!at_norm_char(s)) || ((*s) && (*s) == ' ')))
 #define AT_NORM_CHAR(s)  at_norm_char(s)
 
 /* is the string for makedir a directory name or a filename? */


### PR DESCRIPTION
Testing, I found that `AT_NORM_CHAR(s)` behaved differently for `s` starting with `0`. Fixed that in `at_norm_char(s)`.

I also found that `AT_GREY_SPACE(s)` was not *entirely* the inverse of `AT_NORM_CHAR(s)`, it also skips 0x20, SPACE. Fixed in the macro.